### PR TITLE
- Fix #380 

### DIFF
--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/features/impl/party/customgui/PanelPartyFinder.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/features/impl/party/customgui/PanelPartyFinder.java
@@ -119,7 +119,7 @@ public class PanelPartyFinder extends MPanel {
             Minecraft.getMinecraft().displayGuiScreen(adapter);
 
             Navigator.getNavigator(mainConfigWidget.getDomElement()).openPage(
-                    new CategoryPageWidget("Party")
+                    new CategoryPageWidget("Dungeon Party")
             );
         });
         discordInvite = new MButton();


### PR DESCRIPTION
settings dialogue from custom party finder was being linked to wrong category

This pr correctly corrects it to "Dungeon Party" from just "Party"