### PR TITLE
Fix 2GB/sec memory allocation on pathfinders

### DIFF
--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/DungeonContext.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/DungeonContext.java
@@ -51,6 +51,7 @@ import net.minecraftforge.common.MinecraftForge;
 
 import javax.vecmath.Vector2d;
 import java.awt.*;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -70,7 +71,7 @@ public class DungeonContext {
     private DungeonEventRecorder recorder = new DungeonEventRecorder();
 
     @Getter
-    private List<PathfinderExecutor> executors = new CopyOnWriteArrayList<>();
+    private List<WeakReference<PathfinderExecutor>> executors = new CopyOnWriteArrayList<>();
 
 
     @Getter
@@ -165,7 +166,9 @@ public class DungeonContext {
                     dungeonRoom.tryRematch();
                 }
             }
+            executor.setRoomIn(scaffoldParser.getRoomMap().get(getScaffoldParser().getDungeonMapLayout().worldPointToRoomPoint(Minecraft.getMinecraft().thePlayer.getPosition())));
         }
+
 
         players.clear();
         players.addAll(TabListUtil.getPlayersInDungeon());

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/AbstractAction.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/AbstractAction.java
@@ -51,6 +51,10 @@ public abstract class AbstractAction {
 
     }
 
+    public void cleanup(DungeonRoom dungeonRoom, ActionRouteProperties actionRouteProperties) {
+
+    }
+
     public Set<AbstractAction> getPreRequisites(DungeonRoom dungeonRoom) {
         return null;
     }

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/ActionMove.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/ActionMove.java
@@ -105,6 +105,10 @@ public class ActionMove extends AbstractAction {
         }
     }
 
+    @Override
+    public void cleanup(DungeonRoom dungeonRoom, ActionRouteProperties actionRouteProperties) {
+        executor = null;
+    }
 
     public void forceRefresh(DungeonRoom dungeonRoom) {
         if (executor == null) executor = dungeonRoom.createEntityPathTo(target.getBlockPos(dungeonRoom));

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/ActionMoveNearestAir.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/ActionMoveNearestAir.java
@@ -78,6 +78,11 @@ public class ActionMoveNearestAir extends AbstractAction {
         }
     }
 
+    @Override
+    public void cleanup(DungeonRoom dungeonRoom, ActionRouteProperties actionRouteProperties) {
+        executor = null;
+    }
+
     public void forceRefresh(DungeonRoom dungeonRoom) {
         if (executor == null) executor = dungeonRoom.createEntityPathTo(target.getBlockPos(dungeonRoom));
         executor.setTarget(Minecraft.getMinecraft().thePlayer.getPositionVector());

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/tree/ActionRoute.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/actions/tree/ActionRoute.java
@@ -60,6 +60,10 @@ public class ActionRoute {
     }
 
     public AbstractAction next() {
+        if (!(getCurrentAction() instanceof  ActionMove || getCurrentAction() instanceof  ActionMoveNearestAir))
+            getCurrentAction().cleanup(dungeonRoom, actionRouteProperties);
+        if (this.current -1 >= 0 && (actions.get(this.current-1) instanceof ActionMove || actions.get(this.current-1) instanceof ActionMoveNearestAir))
+            actions.get(this.current-1).cleanup(dungeonRoom, actionRouteProperties);
         current ++;
         if (current >= actions.size()) {
             current = actions.size() - 1;

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/AStarCornerCut.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/AStarCornerCut.java
@@ -74,7 +74,7 @@ public class AStarCornerCut  implements IPathfinder {
     public boolean doOneStep() {
         if (found) return true;
         Node n = open.poll();
-        if (n == null) return false;
+        if (n == null) return true;
         if (n.lastVisited == pfindIdx) return false;
         n.lastVisited = pfindIdx;
 

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/AStarFineGrid.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/AStarFineGrid.java
@@ -73,7 +73,7 @@ public class AStarFineGrid implements IPathfinder {
     public boolean doOneStep() {
         if (found) return true;
         Node n = open.poll();
-        if (n == null) return false;
+        if (n == null) return true;
         if (n.lastVisited == pfindIdx) return false;
         n.lastVisited = pfindIdx;
 

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/PathfinderExecutor.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/PathfinderExecutor.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class PathfinderExecutor {
     private boolean invalidate = false;
     @Getter
-    private Vec3 target;
+    private volatile Vec3 target;
 
     @Getter
     private DungeonRoom dungeonRoom;

--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/ThetaStar.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/dungeon/pathfinding/algorithms/ThetaStar.java
@@ -73,7 +73,7 @@ public class ThetaStar implements IPathfinder {
     public boolean doOneStep() {
         if (found) return true;
         Node n = open.poll();
-        if (n == null) return false;
+        if (n == null) return true; // nothing more to search. this means no route.
         if (n.lastVisited == pfindIdx) return false;
         n.lastVisited = pfindIdx;
 


### PR DESCRIPTION
- WeakReference on PathfindExecutors
- OPTIMIZE New Object Creation on PathfinderExecutorExecutor, it was previously allocating 2GB/sec (lol)
- Cleanup reference to Executor for it to be garbage collected
- Volatile on target on executor, sometimes it was not updating
- Fix pathfind stopping if visited all open nodes
- Fix isBlocked array not correctly being updated due to multi-threading

Fixes #361 and #363 hopefully