### PR TITLE
- Fix #437, ability cooldown now checks isinDungeon not isinSkyblock

### DIFF
--- a/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/features/impl/etc/ability/FeatureAbilityCooldown.java
+++ b/mod/src/main/java/kr/syeyoung/dungeonsguide/mod/features/impl/etc/ability/FeatureAbilityCooldown.java
@@ -58,7 +58,7 @@ public class FeatureAbilityCooldown extends TextHUDFeature {
 
     @Override
     public boolean isHUDViewable() {
-        return SkyblockStatus.isOnSkyblock() && (!this.<Boolean>getParameter("disable").getValue() || (this.<Boolean>getParameter("disable").getValue() && SkyblockStatus.isOnSkyblock()));
+        return SkyblockStatus.isOnSkyblock() && (!this.<Boolean>getParameter("disable").getValue() || (this.<Boolean>getParameter("disable").getValue() && SkyblockStatus.isOnDungeon()));
     }
 
 


### PR DESCRIPTION
Close #437