### PR TITLE
Prevent multiple auth notifs.

### DIFF
--- a/loader/src/main/java/kr/syeyoung/dungeonsguide/launcher/auth/AuthManager.java
+++ b/loader/src/main/java/kr/syeyoung/dungeonsguide/launcher/auth/AuthManager.java
@@ -49,7 +49,7 @@ public class AuthManager {
     Logger logger = LogManager.getLogger("AuthManger");
 
     private static AuthManager INSTANCE;
-
+    private boolean shouldAuthNotif = true;
     public static AuthManager getInstance() {
         if(INSTANCE == null) INSTANCE = new AuthManager();
         return INSTANCE;
@@ -153,14 +153,19 @@ public class AuthManager {
                         .build()));
             } else {
                 currentToken = new FailedAuthToken(e);
-                NotificationManager.getInstance().updateNotification(authenticationFailure, new WidgetNotification(authenticationFailure, Notification.builder()
-                        .title("Auth Error")
-                        .description("Authentication Error Occurred\n"+e.getMessage())
-                        .titleColor(0xFFFF0000)
-                        .onClick(() -> {
-                            GuiDisplayer.INSTANCE.displayGui(new GuiScreenAdapter(new GlobalHUDScale(new WidgetError(e))));
-                        })
-                        .build()));
+                if(shouldAuthNotif){
+                    NotificationManager.getInstance().updateNotification(authenticationFailure, new WidgetNotification(authenticationFailure, Notification.builder()
+                            .title("Auth Error")
+                            .description("Authentication Error Occurred\n"+e.getMessage())
+                            .titleColor(0xFFFF0000)
+                            .onClick(() -> {
+                                NotificationManager.getInstance().removeNotification(authenticationFailure);
+                                shouldAuthNotif = false;
+                                GuiDisplayer.INSTANCE.displayGui(new GuiScreenAdapter(new GlobalHUDScale(new WidgetError(e))));
+                            })
+                            .build()));
+                }
+
             }
             logger.error("Re-auth failed with message {}, trying again in a 2 seconds", String.valueOf(Throwables.getRootCause(e)));
             throw new AuthFailedException(e);
@@ -206,14 +211,19 @@ public class AuthManager {
                             .build()));
                 } else {
                     currentToken = new FailedAuthToken(e);
-                    NotificationManager.getInstance().updateNotification(authenticationFailure, new WidgetNotification(authenticationFailure, Notification.builder()
-                            .title("Auth Error")
-                            .description("Authentication Error Occurred\n"+e.getMessage())
-                            .titleColor(0xFFFF0000)
-                            .onClick(() -> {
-                                GuiDisplayer.INSTANCE.displayGui(new GuiScreenAdapter(new GlobalHUDScale(new WidgetError(e))));
-                            })
-                            .build()));
+                    if(shouldAuthNotif) {
+
+                        NotificationManager.getInstance().updateNotification(authenticationFailure, new WidgetNotification(authenticationFailure, Notification.builder()
+                                .title("Auth Error")
+                                .description("Authentication Error Occurred\n" + e.getMessage())
+                                .titleColor(0xFFFF0000)
+                                .onClick(() -> {
+                                    shouldAuthNotif = false;
+                                    NotificationManager.getInstance().removeNotification(authenticationFailure);
+                                    GuiDisplayer.INSTANCE.displayGui(new GuiScreenAdapter(new GlobalHUDScale(new WidgetError(e))));
+                                })
+                                .build()));
+                    }
                 }
                 logger.error("Accepting the Privacy Policy failed with message {}, trying again in a 2 seconds", String.valueOf(Throwables.getRootCause(e)));
                 throw new AuthFailedException(e);

--- a/loader/src/main/java/kr/syeyoung/dungeonsguide/launcher/auth/AuthManager.java
+++ b/loader/src/main/java/kr/syeyoung/dungeonsguide/launcher/auth/AuthManager.java
@@ -159,8 +159,8 @@ public class AuthManager {
                             .description("Authentication Error Occurred\n"+e.getMessage())
                             .titleColor(0xFFFF0000)
                             .onClick(() -> {
-                                NotificationManager.getInstance().removeNotification(authenticationFailure);
                                 shouldAuthNotif = false;
+                                NotificationManager.getInstance().removeNotification(authenticationFailure);
                                 GuiDisplayer.INSTANCE.displayGui(new GuiScreenAdapter(new GlobalHUDScale(new WidgetError(e))));
                             })
                             .build()));


### PR DESCRIPTION
Allows you to close Authentication Failure notifs and makes only 1 able to appear per boot.

The error being permanently glued to the bottom of a user's screen isn't helpful to anyone. 